### PR TITLE
fix: write exception to stderr

### DIFF
--- a/shipper.py
+++ b/shipper.py
@@ -18,7 +18,7 @@ with open("config.yml", 'r') as config_file:
         config = yaml.load(config_file)
         print config
     except yaml.YAMLError as exc:
-        print exc
+        print >> sys.stderr, exc
         sys.exit(1)
 
 connected = False


### PR DESCRIPTION
Currently the exception is printed to stdout
